### PR TITLE
only call reportDialerConnClosed when conn close succeeds

### DIFF
--- a/dialer_wrapper.go
+++ b/dialer_wrapper.go
@@ -159,7 +159,7 @@ func (ct *clientConnTracker) Close() error {
 		ct.event = nil
 	}
 	ct.mu.Unlock()
-	if ct.opts.monitoring {
+	if ct.opts.monitoring && err == nil {
 		reportDialerConnClosed(ct.dialerName)
 	}
 	return err


### PR DESCRIPTION
feels like `reportDialerConnClosed` shouldn't be called unless `Conn.Close()` succeeds

By @tugberkugurlu at https://github.com/mwitkow/go-conntrack/pull/12