### PR TITLE
Update Go linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,25 +1,34 @@
+---
 name: golangci-lint
 on:
   push:
-    branches:
-      - main
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
   pull_request:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '1.21'
-          check-latest: true
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+          go-version: 1.24.x
+      - name: Lint
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
+          args: --verbose
           version: v1.64

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+linters:
+  enable:
+    - misspell
+
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - errcheck
+
+linters-settings:
+  errcheck:
+    exclude-functions:
+      # Used in HTTP handlers, any error is handled by the server itself.
+      - (net/http.ResponseWriter).Write

--- a/connhelpers/tls.go
+++ b/connhelpers/tls.go
@@ -41,9 +41,6 @@ func TlsConfigWithHttp2Enabled(config *tls.Config) (*tls.Config, error) {
 		}
 	}
 
-	//nolint:staticcheck
-	config.PreferServerCipherSuites = true
-
 	haveNPN := false
 	for _, p := range config.NextProtos {
 		if p == "h2" {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/marefr/go-conntrack
 
-go 1.24.1
+go 1.23.0
 
 require (
 	github.com/jpillora/backoff v1.0.0
-	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/prometheus/client_golang v1.21.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/net v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
-github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.21.1 h1:DOvXXTqVzvkIewV/CDPFdejpMCGeMcbGCQ8YOmu+Ibk=


### PR DESCRIPTION
* Set minimum Go version to 1.23.x to match current versions.
* `go mod tidy`
* Enable golangci-lint.
* Fixup linter issues.